### PR TITLE
feat: add support for validating selected feeds

### DIFF
--- a/src/frontend/fresh.gen.ts
+++ b/src/frontend/fresh.gen.ts
@@ -16,6 +16,7 @@ import * as $ws from "./routes/ws.ts";
 import * as $Counter from "./islands/Counter.tsx";
 import * as $ExportButton from "./islands/ExportButton.tsx";
 import * as $FeedListControls from "./islands/FeedListControls.tsx";
+import * as $FeedManagementIsland from "./islands/FeedManagementIsland.tsx";
 import * as $OPMLUploaderIsland from "./islands/OPMLUploaderIsland.tsx";
 import * as $ValidationStatus from "./islands/ValidationStatus.tsx";
 import type { Manifest } from "$fresh/server.ts";
@@ -38,6 +39,7 @@ const manifest = {
     "./islands/Counter.tsx": $Counter,
     "./islands/ExportButton.tsx": $ExportButton,
     "./islands/FeedListControls.tsx": $FeedListControls,
+    "./islands/FeedManagementIsland.tsx": $FeedManagementIsland,
     "./islands/OPMLUploaderIsland.tsx": $OPMLUploaderIsland,
     "./islands/ValidationStatus.tsx": $ValidationStatus,
   },

--- a/src/frontend/islands/FeedListControls.tsx
+++ b/src/frontend/islands/FeedListControls.tsx
@@ -8,12 +8,13 @@ import type { FeedRecord, FeedStatus } from "../../backend/types/feed.types.ts";
 interface FeedListControlsProps {
   feeds: FeedRecord[];
   isLoading?: boolean;
+  onSelectionChange?: (selectedFeeds: Set<string>) => void;
 }
 
 type SortField = 'url' | 'category' | 'status' | 'lastUpdate' | 'updatesInLast3Months' | 'lastValidated';
 type SortDirection = 'asc' | 'desc';
 
-export default function FeedListControls({ feeds, isLoading = false }: FeedListControlsProps) {
+export default function FeedListControls({ feeds, isLoading = false, onSelectionChange }: FeedListControlsProps) {
   const [error, setError] = useState<string | null>(null);
 
   // Filter states
@@ -156,6 +157,13 @@ export default function FeedListControls({ feeds, isLoading = false }: FeedListC
   // This prevents potential infinite loops
   }, [statusFilter, categoryFilter, searchQuery, feeds, selectedFeeds]);
 
+  // Notify parent component when selection changes
+  useEffect(() => {
+    if (onSelectionChange) {
+      onSelectionChange(selectedFeeds);
+    }
+  }, [selectedFeeds, onSelectionChange]);
+
   // Reset filters
   const handleResetFilters = () => {
     setStatusFilter('all');
@@ -213,31 +221,6 @@ export default function FeedListControls({ feeds, isLoading = false }: FeedListC
   };
 
   // We're using checkboxes for selection instead of dropdown menu
-
-  const handleRefresh = async () => {
-    try {
-      setError(null);
-      const response = await fetch("/api/feeds", {
-        method: "GET",
-        headers: {
-          "Cache-Control": "no-cache"
-        }
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("Failed to refresh feeds:", errorText);
-        setError("Failed to refresh feeds. Please try again later.");
-      }
-
-      // The parent component will handle updating the feeds
-      // This is just to trigger a refresh request
-      globalThis.location.reload();
-    } catch (error) {
-      console.error("Error refreshing feeds:", error);
-      setError("An unexpected error occurred. Please try again later.");
-    }
-  };
 
   // Get sort icon based on current sort state
   const getSortIcon = (field: SortField) => {
@@ -361,18 +344,6 @@ export default function FeedListControls({ feeds, isLoading = false }: FeedListC
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                   </svg>
                   Reset
-                </button>
-
-                <button
-                  type="button"
-                  onClick={handleRefresh}
-                  disabled={isLoading}
-                  class={`inline-flex items-center px-3 py-2 border border-slate-300 rounded-md shadow-sm text-sm font-medium ${isLoading ? 'opacity-50 cursor-not-allowed bg-slate-100' : 'bg-white hover:bg-slate-50'} text-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
-                >
-                  <svg class={`-ml-0.5 mr-1.5 h-4 w-4 text-slate-500 ${isLoading ? 'animate-spin' : ''}`} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" />
-                  </svg>
-                  {isLoading ? 'Refreshing...' : 'Refresh'}
                 </button>
               </div>
             </div>

--- a/src/frontend/islands/FeedManagementIsland.tsx
+++ b/src/frontend/islands/FeedManagementIsland.tsx
@@ -1,0 +1,64 @@
+// src/frontend/islands/FeedManagementIsland.tsx
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import FeedListControls from "./FeedListControls.tsx";
+import ValidationStatus from "./ValidationStatus.tsx";
+import type { FeedRecord } from "../../backend/types/feed.types.ts";
+
+/**
+ * FeedManagementIsland is responsible for managing feed data, selection, and validation.
+ * It contains both the feed list controls and validation status components.
+ */
+export default function FeedManagementIsland() {
+  // Feed data state
+  const feeds = useSignal<FeedRecord[]>([]);
+  const isLoading = useSignal<boolean>(true);
+
+  // Selection state
+  const selectedFeeds = useSignal<Set<string>>(new Set<string>());
+
+  // Fetch feeds from the API
+  const fetchFeeds = async () => {
+    try {
+      isLoading.value = true;
+
+      // Set a high limit to fetch all feeds since we don't have pagination yet
+      const response = await fetch("/api/feeds?limit=1000");
+      if (!response.ok) {
+        throw new Error(`Failed to fetch feeds: ${response.status}`);
+      }
+
+      const data = await response.json();
+      feeds.value = data.feeds || [];
+      console.log(`Fetched ${data.feeds?.length || 0} feeds`);
+    } catch (error) {
+      console.error("Error fetching feeds:", error);
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  // Load feeds on component mount
+  useEffect(() => {
+    fetchFeeds();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      {/* Validation Status component */}
+      <ValidationStatus
+        feedCount={feeds.value.length}
+        selectedFeeds={selectedFeeds.value}
+        allFeeds={feeds.value}
+        onValidationComplete={fetchFeeds}
+      />
+
+      {/* Feed List Controls component */}
+      <FeedListControls
+        feeds={feeds.value}
+        isLoading={isLoading.value}
+        onSelectionChange={(newSelection) => selectedFeeds.value = newSelection}
+      />
+    </div>
+  );
+}

--- a/src/frontend/islands/OPMLUploaderIsland.tsx
+++ b/src/frontend/islands/OPMLUploaderIsland.tsx
@@ -83,7 +83,7 @@ export default function OPMLUploaderIsland() {
       uploadStatus.value = "success";
       // Trigger a page reload to refresh all components
       setTimeout(() => {
-        window.location.reload();
+        globalThis.location.reload();
       }, 1000);
 
     } catch (error) {

--- a/src/frontend/islands/OPMLUploaderIsland.tsx
+++ b/src/frontend/islands/OPMLUploaderIsland.tsx
@@ -1,26 +1,19 @@
 // src/frontend/islands/OPMLUploaderIsland.tsx
 import { useSignal } from "@preact/signals";
 import { JSX } from "preact";
-import { useEffect, useRef } from "preact/hooks";
 import OPMLUploader from "../components/OPMLUploader.tsx";
-import FeedListControls from "./FeedListControls.tsx";
-import ValidationStatus from "./ValidationStatus.tsx";
-import type { FeedRecord } from "../../backend/types/feed.types.ts";
-import type { ListFeedsResult } from "../../backend/types/storage.types.ts";
 
 type UploadStatus = "idle" | "uploading" | "success" | "error";
 
+/**
+ * OPMLUploaderIsland is responsible for handling OPML file uploads.
+ * It has been simplified to focus only on the upload functionality.
+ */
 export default function OPMLUploaderIsland() {
   const selectedFile = useSignal<File | null>(null);
   const selectedFileName = useSignal<string | null>(null);
   const uploadStatus = useSignal<UploadStatus>("idle");
   const uploadErrorMessage = useSignal<string | null>(null);
-  const feeds = useSignal<FeedRecord[]>([]);
-  const previousFeeds = useSignal<FeedRecord[]>([]);
-  const areFeedsLoading = useSignal<boolean>(true);
-  // Add a signal for tracking the last update timestamp to enable smooth transitions
-  const lastUpdateTimestamp = useSignal<number>(Date.now());
-  // We'll keep the previousFeeds signal but remove the visual transition
 
   /**
    * Check if a file is potentially compatible with OPML format
@@ -64,72 +57,6 @@ export default function OPMLUploaderIsland() {
     }
   };
 
-  // Keep track of scroll position
-  const scrollPositionRef = useRef<number>(0);
-
-  // Function to save current scroll position
-  const saveScrollPosition = () => {
-    // Use globalThis instead of window for Deno compatibility
-    scrollPositionRef.current = globalThis.scrollY;
-  };
-
-  // Function to restore scroll position
-  const restoreScrollPosition = () => {
-    // Use globalThis instead of window for Deno compatibility
-    globalThis.scrollTo({
-      top: scrollPositionRef.current,
-      behavior: 'auto' // Use 'auto' to prevent animation
-    });
-  };
-
-  const fetchFeeds = async (limit = 500) => {
-    // Save current scroll position before fetching
-    saveScrollPosition();
-
-    // We'll keep using previousFeeds for continuity, but without visual transitions
-
-    // Only set loading to true if we don't have any previous data
-    // This prevents the component from showing a loading spinner when we already have data to display
-    if (feeds.value.length === 0) {
-      areFeedsLoading.value = true;
-    }
-
-    console.log("Fetching feeds...");
-    try {
-      const response = await fetch(`/api/feeds?limit=${limit}`, {
-        headers: {
-          "Cache-Control": "no-cache"
-        }
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch feeds: ${response.statusText}`);
-      }
-      const result: ListFeedsResult = await response.json();
-
-      // Store current feeds as previous before updating
-      if (feeds.value.length > 0) {
-        previousFeeds.value = [...feeds.value];
-      }
-
-      // Update with new data
-      feeds.value = result.feeds;
-      console.log("Feeds fetched:", result.feeds.length);
-
-      // Update timestamp for animation triggers
-      lastUpdateTimestamp.value = Date.now();
-    } catch (error) {
-      console.error("Error fetching feeds:", error);
-    } finally {
-      // End loading state
-      areFeedsLoading.value = false;
-
-      // No need for transition delay anymore
-
-      // Restore scroll position after updating
-      setTimeout(restoreScrollPosition, 0);
-    }
-  };
-
   const handleUpload = async () => {
     if (!selectedFile.value) {
       uploadErrorMessage.value = "Please select a file first.";
@@ -154,7 +81,10 @@ export default function OPMLUploaderIsland() {
       }
 
       uploadStatus.value = "success";
-      await fetchFeeds();
+      // Trigger a page reload to refresh all components
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
 
     } catch (error) {
       console.error("Upload error:", error);
@@ -163,40 +93,15 @@ export default function OPMLUploaderIsland() {
     }
   };
 
-
-
-  useEffect(() => {
-    fetchFeeds();
-  }, []);
-
   return (
-    <div class="flex flex-col items-center space-y-6 w-full">
-      {/* Main container with consistent width for all components */}
-      <div class="w-full max-w-6xl mx-auto">
-        <OPMLUploader
-          onFileChange={handleFileChange}
-          onUpload={handleUpload}
-          uploadStatus={uploadStatus.value}
-          errorMessage={uploadErrorMessage.value}
-          selectedFileName={selectedFileName.value}
-        />
-
-        {/* Validation Status component */}
-        <div class="mt-6">
-          <ValidationStatus
-            feedCount={feeds.value.length}
-            onValidationComplete={fetchFeeds}
-          />
-        </div>
-
-        {/* Feed list section using the new FeedListControls component */}
-        <div class="mt-6">
-          <FeedListControls
-            feeds={areFeedsLoading.value && previousFeeds.value.length > 0 ? previousFeeds.value : feeds.value}
-            isLoading={areFeedsLoading.value}
-          />
-        </div>
-      </div>
+    <div class="bg-white border border-slate-200 rounded-lg shadow-sm p-6">
+      <OPMLUploader
+        onFileChange={handleFileChange}
+        onUpload={handleUpload}
+        uploadStatus={uploadStatus.value}
+        errorMessage={uploadErrorMessage.value}
+        selectedFileName={selectedFileName.value}
+      />
     </div>
   );
 }

--- a/src/frontend/routes/index.tsx
+++ b/src/frontend/routes/index.tsx
@@ -1,6 +1,7 @@
 // src/frontend/routes/index.tsx
 import { Head } from "$fresh/runtime.ts";
 import OPMLUploaderIsland from "../islands/OPMLUploaderIsland.tsx";
+import FeedManagementIsland from "../islands/FeedManagementIsland.tsx";
 
 export default function Home() {
   return (
@@ -18,7 +19,7 @@ export default function Home() {
               <div class="flex items-center">
                 <div class="flex-shrink-0 flex items-center">
                   <svg class="h-8 w-8 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7M6 17a1 1 0 011 1" />
                   </svg>
                   <span class="ml-2 text-xl font-semibold text-slate-800">OPML Manager</span>
@@ -43,7 +44,10 @@ export default function Home() {
               <h1 class="text-2xl font-semibold text-slate-900">OPML Subscription Manager</h1>
               <p class="mt-1 text-sm text-slate-500">Upload, manage, and validate your feed subscriptions</p>
             </div>
-            <OPMLUploaderIsland />
+            <div class="space-y-8">
+              <OPMLUploaderIsland />
+              <FeedManagementIsland />
+            </div>
           </div>
         </main>
 


### PR DESCRIPTION
This change adds the ability to validate only selected feeds instead of
validating all feeds at once. This is particularly useful for large feed
collections where users may only want to check a subset of feeds.

Changes:
- Created a new FeedManagementIsland component that manages feed data and selection state
- Simplified OPMLUploaderIsland to focus only on file uploads
- Modified the validation API endpoint to accept a list of feed URLs to validate
- Updated the ValidationStatus component to adapt its button based on selection state
- Updated the FeedListControls component to notify parent of selection changes
- Removed the redundant "Refresh" button to simplify the UI
- Increased feed fetch limit to 1000 to ensure all feeds are visible

This implementation maintains proper separation of concerns and improves
the user experience by providing more targeted validation capabilities.

Fixes #2