### PR TITLE
feat: add support for storing and exporting all RSS feed metadata fields (#5)

### DIFF
--- a/docs/feed-metadata-fields-implementation-plan.md
+++ b/docs/feed-metadata-fields-implementation-plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Add Feed Metadata Fields (title, text, type, htmlUrl) to FeedBase
+
+## Overview
+This plan outlines the steps to enhance the feed data model by adding additional metadata fields (title, text, type, htmlUrl, description) to the `FeedBase` interface. This will enable richer feed representation in storage, API, and UI, and align with standard OPML export/import formats.
+
+---
+
+## Steps
+
+### 1. Update Type Definitions
+- **Refactor** type definitions in `src/backend/types/feed.types.ts` to clarify the domain model:
+  - **FeedBase**: only static, descriptive fields (do not include status or runtime info)
+  - **FeedEntry**: extends FeedBase, adds dynamic/runtime fields (status, lastUpdate, etc.)
+  - **FeedRecord**: extends FeedEntry, adds validation workflow specific fields (userId, lastValidated, category, etc.)
+
+- The interfaces will be:
+```typescript
+export interface FeedBase {
+    /** The URL of the feed (corresponds to xmlUrl in OPML) */
+    url: string;
+    /** Display name from OPML (the 'text' attribute, mandatory in OPML) */
+    text: string;
+    /** Feed's human-readable title (from RSS or OPML, optional but often simply duplicate the value of 'text') */
+    title?: string;
+    /** Feed type, usually 'rss' (optional, from OPML) */
+    type?: string;
+    /** Website URL for the feed (optional, from OPML) */
+    htmlUrl?: string;
+    /** Description from RSS/OPML (optional) */
+    description?: string;
+}
+
+export interface FeedEntry extends FeedBase {
+    /** Current status of the feed (active/inactive/dead/incompatible) */
+    status: FeedStatus;
+    /** Most recent update time of the feed, null if never updated or inaccessible */
+    lastUpdate: string | null;
+    /** Number of updates in the last 3 months */
+    updatesInLast3Months: number;
+    /** Reason for incompatibility if status is 'incompatible' */
+    incompatibleReason?: string;
+}
+
+export interface FeedRecord extends FeedEntry {
+    /** User this feed belongs to */
+    userId: string;
+    /** Category the feed belongs to */
+    category: string;
+    /** When the feed was last validated */
+    lastValidated: string | null;
+    /** History of validation attempts and results */
+    validationHistory: ValidationHistory[];
+    // ...other storage-specific fields
+}
+```
+
+
+### 2. Update Feed Parsing and Data Population
+- **In** `getFeedUpdateFrequency.ts`:
+  - When parsing the RSS feed XML, extract the `text` (and any other available fields).
+  - Populate the new fields in the returned `FeedEntry` object.
+- **In** `parseOPML.ts`:
+  - When importing feeds from OPML, extract and store `text`, `title`, `type`, and `htmlUrl`, `description` from each `<outline>` element.
+  - If `title` is missing, use the `text` value as a fallback.
+  - If `type` is missing, use 'rss' as a fallback.
+  - If `htmlUrl` is missing, just leave it blank.
+  - If `description` is missing, just leave it blank.
+
+### 3. Update Storage Layer
+- Ensure that the KV storage (and any other persistence layer) saves and retrieves the new fields as part of the feed record.
+
+### 4. Update OPML Generation
+- **In** `generateNewOPML.ts`:
+  - Include the new fields (`title`, `text`, `type`, `htmlUrl`, `description`) when generating `<outline>` elements for export.
+  - Ensure the output matches standard OPML structure for compatibility with other readers.
+
+### 5. Update API and Data Flow
+- Update API endpoints (if needed) to support the new fields in requests and responses.
+
+### 6. Update Frontend UI
+- **Feed List:**
+  - Display the new fields (prefer `text` for display; fallback to `url` if missing).
+  - Use `url` as the `text` hover display.
+- **Feed Details/Export:**
+  - Ensure the new fields are included in exported OPML files and any detailed feed views.
+
+### 7. Testing & Validation
+- Add/extend unit and integration tests to cover:
+  - Feed import (OPML/XML parsing)
+  - Feed export (OPML generation)
+  - API responses
+  - UI display of new fields
+
+### 8. Migration (Optional)
+- For existing feeds in storage, consider a migration script or background job to backfill `title` and other fields by re-parsing feeds if necessary.
+
+---
+
+## Notes
+- Avoid adding `xmlUrl` since `url` already fulfills this role.
+- Make new fields optional if some feeds may not have all metadata available.
+- This plan ensures richer, more user-friendly feed data throughout the application.

--- a/src/backend/generateNewOPML.ts
+++ b/src/backend/generateNewOPML.ts
@@ -49,7 +49,7 @@ function generateOPMLContent(opmlData: FeedCollection, status: FeedStatus, title
         // For incompatible feeds, include the reason in a comment attribute
         // Fallback logic for each field
         const text = feed.text || feed.title || feed.url;
-        const title = feed.title || text;
+        const title = text;
         const type = feed.type || 'rss';
         const htmlUrl = feed.htmlUrl || '';
         const description = feed.description || '';

--- a/src/backend/getFeedUpdateFrequency.ts
+++ b/src/backend/getFeedUpdateFrequency.ts
@@ -36,9 +36,9 @@ function makeXmlCompatible(value: string): string {
 
 function makeFeedEntry(partial: Partial<FeedEntry>): FeedEntry {
   return {
-    url: partial.url ? makeXmlCompatible(partial.url) : '',
-    text: partial.text ? makeXmlCompatible(partial.text) : (partial.url ? makeXmlCompatible(partial.url) : ''),
-    title: partial.title ? makeXmlCompatible(partial.title) : (partial.text ? makeXmlCompatible(partial.text) : (partial.url ? makeXmlCompatible(partial.url) : '')),
+    url: makeXmlCompatible(partial.url ?? ''),
+    text: makeXmlCompatible(partial.text ?? partial.url ?? ''),
+    title: makeXmlCompatible(partial.title ?? partial.text ?? partial.url ?? ''),
     type: partial.type || 'rss',
     htmlUrl: partial.htmlUrl || '',
     description: partial.description ? makeXmlCompatible(partial.description) : '',

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -62,10 +62,12 @@ async function main() {
         feed.status = feedStatus.status;
         feed.lastUpdate = feedStatus.lastUpdate;
         feed.updatesInLast3Months = feedStatus.updatesInLast3Months;
-        // Add incompatible reason if feed became incompatible
-        if (feedStatus.status === 'incompatible') {
-          feed.incompatibleReason = feedStatus.incompatibleReason;
-        }
+        feed.text = feedStatus.text;
+        feed.title = feedStatus.title;
+        feed.type = feedStatus.type;
+        feed.htmlUrl = feedStatus.htmlUrl;
+        feed.description = feedStatus.description;
+        feed.incompatibleReason = feedStatus.incompatibleReason;
         logger.info(`Feed status: ${feed.status}${feedStatus.incompatibleReason ? ': ' + feedStatus.incompatibleReason : ''}`);
       } else {
         logger.info(`Feed marked as ${feed.status}${feed.incompatibleReason ? ': ' + feed.incompatibleReason : ''}`);

--- a/src/backend/parseOPML.ts
+++ b/src/backend/parseOPML.ts
@@ -63,11 +63,21 @@ function parseOpmlXml(xml: string): FeedCollection {
       if (!categories[category]) {
         categories[category] = [];
       }
-      // Add feed to its category with initial dead status
+      // Extract OPML feed metadata fields with fallbacks
+      const text = outline["@text"] || outline["@title"] || outline["@xmlUrl"];
+      const title = outline["@title"] || text;
+      const type = outline["@type"] || 'rss';
+      const htmlUrl = outline["@htmlUrl"] || '';
+      const description = outline["@description"] || '';
       categories[category].push({
         url: outline["@xmlUrl"],
+        text,
+        title,
+        type,
+        htmlUrl,
+        description,
         status: "dead",
-        lastUpdate: null,
+        lastUpdate: undefined,
         updatesInLast3Months: 0,
       } as FeedEntry);
       logger.debug(`Added feed ${outline["@xmlUrl"]} to category ${category}`);

--- a/src/backend/services/storage/storage.impl.ts
+++ b/src/backend/services/storage/storage.impl.ts
@@ -169,6 +169,8 @@ export class KVStorageService implements IKVStorageService {
       // Skip entries before cursor position
       if (options.cursor && count <= parseInt(options.cursor)) continue;
       
+      // DEBUG: Log each FeedRecord being returned
+      //logger.debug("Returning FeedRecord:", JSON.stringify(entry.value));
       feeds.push(entry.value);
       // Check if we've reached the requested limit
       if (feeds.length === (options.limit || 20)) {

--- a/src/backend/services/validation/validation.impl.ts
+++ b/src/backend/services/validation/validation.impl.ts
@@ -156,11 +156,17 @@ export class ValidationServiceImpl {
                 
                 if (existingFeed?.value) {
                   const feed = existingFeed.value;
+                  logger.debug(`Updating feed data for ${url}:`, JSON.stringify(result));
                   await this.storage.updateFeedData(userId, url, {
                     status: result.status,
                     lastUpdate: result.lastUpdate || feed.lastUpdate,
                     updatesInLast3Months: result.updatesInLast3Months || feed.updatesInLast3Months,
                     incompatibleReason: result.error || feed.incompatibleReason,
+                    text: result.text || feed.text,
+                    title: result.title || feed.title,
+                    type: result.type || feed.type,
+                    htmlUrl: result.htmlUrl || feed.htmlUrl,
+                    description: result.description || feed.description,
                     lastValidated: now,
                     validationHistory: [
                       ...(feed.validationHistory || []).slice(0, 9),
@@ -239,12 +245,10 @@ export class ValidationServiceImpl {
     // Check update frequency for compatible feeds
     const updateCheck = await getFeedUpdateFrequency(url);
     return {
-      url,
-      status: updateCheck.status,
-      error: updateCheck.incompatibleReason,
-      lastUpdate: updateCheck.lastUpdate || undefined, // Convert null to undefined to match expected type
-      updatesInLast3Months: updateCheck.updatesInLast3Months
+      ...updateCheck,
+      error: updateCheck.incompatibleReason // For compatibility with existing code
     };
+
   }
 
   private async updateProgress(userId: string, validationId: string, progress: ValidationProgress): Promise<void> {

--- a/src/backend/types/feed.types.ts
+++ b/src/backend/types/feed.types.ts
@@ -11,16 +11,18 @@ export type FeedStatus = 'active' | 'inactive' | 'dead' | 'incompatible';
  * Base feed interface with common properties shared across the application
  */
 export interface FeedBase {
-    /** The URL of the feed */
+    /** The URL of the feed (corresponds to xmlUrl in OPML) */
     url: string;
-    /** Current status of the feed (active/inactive/dead/incompatible) */
-    status: FeedStatus;
-    /** Most recent update time of the feed, null if never updated or inaccessible */
-    lastUpdate: string | null;
-    /** Number of updates in the last 3 months */
-    updatesInLast3Months: number;
-    /** Reason for incompatibility if status is 'incompatible' */
-    incompatibleReason?: string;
+    /** Display name from OPML (the 'text' attribute, mandatory in OPML) */
+    text: string;
+    /** Feed's human-readable title (from RSS or OPML, optional but often simply duplicate the value of 'text') */
+    title?: string;
+    /** Feed type, usually 'rss' (optional, from OPML) */
+    type?: string;
+    /** Website URL for the feed (optional, from OPML) */
+    htmlUrl?: string;
+    /** Description from RSS/OPML (optional) */
+    description?: string;
 }
 
 /**
@@ -28,14 +30,21 @@ export interface FeedBase {
  * This is equivalent to the previous FeedStatus interface in parseOPML.ts
  */
 export interface FeedEntry extends FeedBase {
-    // Currently identical to FeedBase, but can be extended with specific properties
+    /** Current status of the feed (active/inactive/dead/incompatible) */
+    status: FeedStatus;
+    /** Most recent update time of the feed, null if never updated or inaccessible */
+    lastUpdate: string | undefined;
+    /** Number of updates in the last 3 months */
+    updatesInLast3Months: number;
+    /** Reason for incompatibility if status is 'incompatible' */
+    incompatibleReason?: string;
 }
 
 /**
  * Represents a feed record with all its metadata and validation history
  * Used primarily by the storage service
  */
-export interface FeedRecord extends FeedBase {
+export interface FeedRecord extends FeedEntry {
     /** User this feed belongs to */
     userId: string;
     /** Category the feed belongs to */

--- a/src/backend/types/validation.types.ts
+++ b/src/backend/types/validation.types.ts
@@ -44,8 +44,13 @@ export interface FeedValidationResult {
   url: string;
   status: FeedStatus;
   error?: string;
-  lastUpdate?: string;
+  lastUpdate?: string | undefined;
   updatesInLast3Months?: number;
+  text?: string;
+  title?: string;
+  type?: string;
+  htmlUrl?: string;
+  description?: string;
 }
 
 /**

--- a/src/frontend/components/FeedList.tsx
+++ b/src/frontend/components/FeedList.tsx
@@ -130,7 +130,7 @@ export default function FeedList({
                         />
                       </div>
                     </th>
-                    <SortableHeader field="url" label="URL" />
+                    <SortableHeader field="url" label="Name" />
                     <SortableHeader field="category" label="Category" />
                     <SortableHeader field="status" label="Status" />
                     <SortableHeader field="lastUpdate" label="Last Update" />
@@ -168,8 +168,8 @@ export default function FeedList({
                             }}
                             style={{ maxWidth: 'calc(100% - 1.5rem)' }}
                           >
-                            {/* Display URL with visual indication of truncation */}
-                            <span class="truncate">{feed.url}</span>
+                            {/* Display feed.text, fallback to feed.url if missing */}
+                            <span class="truncate">{feed.text || feed.url}</span>
                           </a>
                         </div>
                       </td>

--- a/src/frontend/routes/api/export.ts
+++ b/src/frontend/routes/api/export.ts
@@ -42,7 +42,7 @@ export const handler: Handlers = {
       
       const opmlContent = generateOPMLForExport(feedCollection, { 
         title: "Exported Feeds",
-        includeAllStatuses: true 
+        includeAllStatuses: true  // Previously, export could filter by status, but since frontend filtering is now available, we always export all statuses by default.
       });
       
       // Create download response with simplified filename format

--- a/src/frontend/routes/api/upload.ts
+++ b/src/frontend/routes/api/upload.ts
@@ -103,8 +103,13 @@ export const handler: Handlers = {
           const feedRecord: FeedRecord = {
             userId: userId!, // Multi-user: associate feed with user
             url: feed.url,
+            text: feed.text,
+            title: feed.title,
+            type: feed.type,
+            htmlUrl: feed.htmlUrl,
+            description: feed.description,
             status: feed.status,
-            lastUpdate: feed.lastUpdate ?? null,
+            lastUpdate: feed.lastUpdate ?? undefined,
             updatesInLast3Months: feed.updatesInLast3Months,
             incompatibleReason: feed.incompatibleReason,
             category,

--- a/src/frontend/routes/api/upload.ts
+++ b/src/frontend/routes/api/upload.ts
@@ -97,6 +97,7 @@ export const handler: Handlers = {
       const storage = await KVStorageService.initialize();
       
       // Process each category and its feeds
+      logger.info(`Processing ${Object.keys(opmlData.categories).length} categories, saving to database...`);
       for (const [category, feeds] of Object.entries(opmlData.categories)) {
         for (const feed of feeds) {
           const feedRecord: FeedRecord = {
@@ -113,6 +114,7 @@ export const handler: Handlers = {
           await storage.saveFeedData(userId!, feedRecord);
         }
       }
+      logger.info(`Processed ${Object.keys(opmlData.categories).length} categories, saved to database successfully`);
 
       // Return success response
       return new Response(JSON.stringify({


### PR DESCRIPTION
- Enhanced feed validation and KV storage to extract and persist all key RSS metadata fields: text (human-readable name), title, type, xmlUrl, htmlUrl, and description.
- Updated the OPML export logic to include these fields as attributes on each outline element, matching common OPML conventions.
- Ensured that the text field is always populated and used as the main label for feeds in the exported OPML and feed list.
- All fields are now XML-compatible and properly escaped to prevent import errors.

Closes #5.